### PR TITLE
chore: pin commerce cli to v0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "clean": "rimraf ./packages/*/dist-* ./packages/*/*.tsbuildinfo",
     "setupTelemetry": "echo {aio-cli-telemetry: {optOut: false}} > ~/.config/aio",
     "install:mesh": "aio plugins:install @adobe/aio-cli-plugin-api-mesh",
-    "install:commerce": "aio plugins:install https://github.com/adobe-commerce/aio-cli-plugin-commerce",
+    "install:commerce": "aio plugins:install https://github.com/adobe-commerce/aio-cli-plugin-commerce#semver:0.1.3",
     "gh:logout": "unset GITHUB_TOKEN",
     "setup": "yarn setupTelemetry && yarn install:mesh && yarn install:commerce && yarn gh:logout",
     "postinstall": "yarn setup"


### PR DESCRIPTION
Partner day has been using "main" which is currently 0.1.3.

I need to push changes to main, and I don't want to affect partner day.

Take this PR!

https://magento.slack.com/archives/C013UDBFBGB/p1745268287769449