### PR TITLE
Revert "bump to 0.2.0 for increased timeout of code sync"

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "clean": "rimraf ./packages/*/dist-* ./packages/*/*.tsbuildinfo",
     "setupTelemetry": "echo {aio-cli-telemetry: {optOut: false}} > ~/.config/aio",
     "install:mesh": "aio plugins:install @adobe/aio-cli-plugin-api-mesh",
-    "install:commerce": "aio plugins:install https://github.com/adobe-commerce/aio-cli-plugin-commerce#semver:0.2.0",
+    "install:commerce": "aio plugins:install https://github.com/adobe-commerce/aio-cli-plugin-commerce#semver:0.1.3",
     "gh:logout": "unset GITHUB_TOKEN",
     "setup": "yarn setupTelemetry && yarn install:mesh && yarn install:commerce && yarn gh:logout",
     "postinstall": "yarn setup"


### PR DESCRIPTION
Reverts adobe-commerce/partner-day-accs#23

When using aio CLI 0.2.0 and `aio commerce init` is run, it does not ask for the template to use for the EDS storefront and uses [hlxsites/aem-boilerplate-commerce](https://github.com/hlxsites/aem-boilerplate-commerce) directly